### PR TITLE
Remove unused requirements from 'install_requires'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(
     long_description=long_description,
     license="MIT",
     classifiers=classifiers,
-    install_requires=['healpy', 'astropy', 'tqdm', 'numpy', 'pandas']
+    install_requires=['tqdm', 'numpy', 'pandas']
     )


### PR DESCRIPTION
Remove healpy and astropy from the 'install_requires', as they aren't used anyways