### PR TITLE
Use find_packages() to allow `import clhs`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup, find_packages
 
 #import clhs
 
@@ -32,5 +29,6 @@ setup(
     long_description=long_description,
     license="MIT",
     classifiers=classifiers,
-    install_requires=['tqdm', 'numpy', 'pandas']
+    install_requires=['tqdm', 'numpy', 'pandas'],
+    packages=find_packages()
     )


### PR DESCRIPTION
Otherwise got import error `No module named 'clhs'`

Use `setuptools` instead of `distutils.core` to make things easier. Ref: https://stackoverflow.com/questions/12966216/make-distutils-in-python-automatically-find-packages